### PR TITLE
Add product filtering support to the API

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -53,6 +53,10 @@ router.get("/", auth.optional, function(req, res, next) {
     query.tagList = { $in: [req.query.tag] };
   }
 
+  if (typeof req.query.title !== "undefined") {
+    query.title = { $regex: req.query.title, $options: "i" };
+  }
+
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,
     req.query.favorited ? User.findOne({ username: req.query.favorited }) : null


### PR DESCRIPTION
# Description

Added a query filter for title in GET /items route.
Included regex filter to match all items where the title contains the given title in query (case insensitive)

For example, for the following items:
`[{title: "My item 1"}, {title: "my item 2"}, {title: "her item 3"}]`

Searching for `/items?title=my` will return the following:
`[{title: "My item 1"}, {title: "my item 2"}]`